### PR TITLE
flag: Add -pthread.

### DIFF
--- a/lib/rand/dune
+++ b/lib/rand/dune
@@ -30,4 +30,5 @@
 (library
  (name rand)
  (public_name randoml.rand)
+ (flags :standard -cclib -pthread)
  (foreign_archives rand))


### PR DESCRIPTION
The CI is still failing because of opam-dune-lint is not available (error code 127).

This should fix https://github.com/ocaml/opam-repository/pull/19057 @mseri