### PR TITLE
Prevent cargo from updating lockfile during build

### DIFF
--- a/lib/rand/dune
+++ b/lib/rand/dune
@@ -16,7 +16,7 @@
    (run mkdir -p .cargo)
    (run cp cargo-config.toml .cargo/config.toml)
    ; cargo build
-   (run cargo build --release --offline)
+   (run cargo build --release --offline --locked)
    ; extract the produced static library
    ; the .so fluff is here to remove errors that we sometimes get from dune
    (run


### PR DESCRIPTION
Under certain conditions cargo will make benign changes to the lockfile during build. This causes problems when it's invoked from dune because it's run from inside the _build directory where all files are marked readonly. Passing `--locked` to `cargo build` prevents it from updating the lockfile.